### PR TITLE
2D fixed

### DIFF
--- a/examples/2D_fracture_example.ipynb
+++ b/examples/2D_fracture_example.ipynb
@@ -101,6 +101,7 @@
     "myfrac.params['mismatch']['value'] = 0.25\n",
     "myfrac.params['model']['value'] = 'smooth'\n",
     "myfrac.params['seed']['value'] = 1\n",
+    "myfrac.params['mean-aperture']['value'] = 128//3\n",
     "myfrac.create_fracture()\n",
     "\n",
     "# create a sheared fracture\n",
@@ -128,11 +129,11 @@
     "ind_slice = 49 # tile along this index\n",
     "\n",
     "# -> frac 1\n",
-    "myfrac.generate_2D(ind=ind_slice, mean_aperture=128//3)\n",
+    "myfrac.generate_2D(ind=ind_slice)\n",
     "myfrac.voxelize(target_size=128) \n",
     "\n",
     "# -> frac 2\n",
-    "myfrac2.generate_2D(ind=ind_slice, mean_aperture=128//3)\n",
+    "myfrac2.generate_2D(ind=ind_slice)\n",
     "myfrac2.voxelize(target_size=128) "
    ]
   },

--- a/src/pysimfrac/src/general/simFrac.py
+++ b/src/pysimfrac/src/general/simFrac.py
@@ -7,7 +7,7 @@ __email__ = "jhyman@lanl.gov"
 """
 SimFrac object class. 
 """
-
+import os, sys
 import numpy as np
 from pysimfrac.src.general.helper_functions import print_error
 

--- a/src/pysimfrac/src/methods/to_2D.py
+++ b/src/pysimfrac/src/methods/to_2D.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 
-def generate_2D(self, ind=None, mean_aperture=28):
+def generate_2D(self, ind=None):
     
     """Generate a 2D representation of the fracture.
 
@@ -10,8 +10,6 @@ def generate_2D(self, ind=None, mean_aperture=28):
     -------------
         ind : int, optional
             Index along the x-axis to select the slice for 2D representation. If not specified, defaults to the middle of the array.
-        mean_aperture : float, optional
-            Target mean aperture value to set for the 2D fracture representation. Default is 28.
 
     Notes
     ---------
@@ -27,7 +25,6 @@ def generate_2D(self, ind=None, mean_aperture=28):
     
     self.top = np.tile( self.top[ind], (self.top.shape[1], 1))
     self.bottom = np.tile( self.bottom[ind], (self.top.shape[1], 1))
-    self.set_mean_aperture(mean_aperture) 
 
 
 

--- a/src/pysimfrac/src/methods/to_2D.py
+++ b/src/pysimfrac/src/methods/to_2D.py
@@ -25,6 +25,7 @@ def generate_2D(self, ind=None):
     
     self.top = np.tile( self.top[ind], (self.top.shape[1], 1))
     self.bottom = np.tile( self.bottom[ind], (self.top.shape[1], 1))
+    self.set_mean_aperture() 
 
 
 


### PR DESCRIPTION
Now the mean aperture is set in examples/2D_fracture_example.ipynb, not in the function generate_2D src/pysimfrac/src/methods/to_2D.py